### PR TITLE
fix: make course creation popover scrollable

### DIFF
--- a/services/frontend/src/components/nav-courses.tsx
+++ b/services/frontend/src/components/nav-courses.tsx
@@ -168,7 +168,7 @@ export function NavCourses() {
         <PopoverContent
           side="right"
           align="start"
-          className="w-[22rem] rounded-xl border border-[var(--study-popover-border)] bg-[var(--study-popover-surface)] p-0 text-[var(--study-ink)] shadow-[var(--study-popover-shadow)] bg-background"
+          className="w-[22rem] max-h-[85vh] overflow-y-auto rounded-xl border border-[var(--study-popover-border)] bg-[var(--study-popover-surface)] p-0 text-[var(--study-ink)] shadow-[var(--study-popover-shadow)] bg-background"
         >
           <div className="relative overflow-hidden rounded-[inherit] px-4 py-4">
             <div


### PR DESCRIPTION
- Add max-height (85vh) to prevent popover overflow
- Enable vertical scrolling for long form content
- Ensure description field and buttons remain accessible
- Improves UX on smaller screens and when form content is lengthy